### PR TITLE
#59 select all stocktake manager

### DIFF
--- a/src/pages/StocktakeManagePage.js
+++ b/src/pages/StocktakeManagePage.js
@@ -151,10 +151,7 @@ export class StocktakeManagePage extends GenericTablePage {
   renderCell(key, item) {
     switch (key) {
       default:
-      case 'code':
-        return item.code;
-      case 'name':
-        return item.name;
+        return item[key];
       case 'selected':
         return {
           type: 'checkable',


### PR DESCRIPTION
Making the cool selectAllToggle behaviour respect checking individual rows is requires rerendering the table with every checkableCell press, which is bad. But the issue that this branch is actually for is resolved.
