### PR TITLE
Changing requisition months sends alert to listeners

### DIFF
--- a/src/pages/RequisitionPage.js
+++ b/src/pages/RequisitionPage.js
@@ -212,6 +212,7 @@ export class RequisitionPage extends GenericTablePage {
             onSelect={(number) => {
               this.props.database.write(() => {
                 this.props.requisition.monthsToSupply = number;
+                this.props.database.save('Requisition', this.props.requisition);
               });
               this.closeModal();
             }}


### PR DESCRIPTION
- Fixes #119
- Presumably also wasn’t syncing months required change, now will
