### PR TITLE
Sorting works

### DIFF
--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -206,6 +206,7 @@ export class CustomerInvoicePage extends GenericTablePage {
           <AutocompleteSelector
             options={database.objects('Item')}
             queryString={'name BEGINSWITH[c] $0 OR code BEGINSWITH[c] $0'}
+            sortByString={'name'}
             onSelect={(item) => {
               database.write(() => {
                 createRecord(database, 'TransactionItem', transaction, item);

--- a/src/pages/CustomerInvoicesPage.js
+++ b/src/pages/CustomerInvoicesPage.js
@@ -143,6 +143,7 @@ export class CustomerInvoicesPage extends GenericTablePage {
             options={this.props.database.objects('Customer')}
             placeholderText="Start typing to select customer"
             queryString={'name BEGINSWITH[c] $0'}
+            sortByString={'name'}
             onSelect={name => {
               this.onNewInvoice(name);
               this.setState({ isCreatingInvoice: false });

--- a/src/pages/RequisitionPage.js
+++ b/src/pages/RequisitionPage.js
@@ -196,6 +196,7 @@ export class RequisitionPage extends GenericTablePage {
           <AutocompleteSelector
             options={this.props.database.objects('Item')}
             queryString={'name BEGINSWITH[c] $0 OR code BEGINSWITH[c] $0'}
+            sortByString={'name'}
             onSelect={(item) => {
               this.props.database.write(() => {
                 createRecord(this.props.database, 'RequisitionItem', this.props.requisition, item);

--- a/src/widgets/AutocompleteSelector.js
+++ b/src/widgets/AutocompleteSelector.js
@@ -38,6 +38,7 @@ export class AutocompleteSelector extends React.Component {
       options,
       onSelect,
       queryString,
+      sortByString,
       placeholderText,
     } = this.props;
 
@@ -47,7 +48,7 @@ export class AutocompleteSelector extends React.Component {
         autoFocus
         autoCapitalize="none"
         autoCorrect={false}
-        data={options.filtered(queryString, this.state.queryText)}
+        data={options.filtered(queryString, this.state.queryText).sorted(sortByString)}
         onChangeText={text => this.setState({ queryText: text })}
         placeholder={placeholderText}
         renderItem={(item) => (
@@ -65,6 +66,7 @@ export class AutocompleteSelector extends React.Component {
 AutocompleteSelector.propTypes = {
   options: React.PropTypes.object.isRequired,
   queryString: React.PropTypes.string.isRequired,
+  sortByString: React.PropTypes.string.isRequired,
   placeholderText: React.PropTypes.string,
   onSelect: React.PropTypes.func.isRequired,
 };

--- a/src/widgets/modals/SelectModal.js
+++ b/src/widgets/modals/SelectModal.js
@@ -18,6 +18,7 @@ export function SelectModal(props) {
     options,
     placeholderText,
     queryString,
+    sortByString,
     ...modalProps,
   } = props;
 
@@ -31,6 +32,7 @@ export function SelectModal(props) {
         options={options}
         placeholderText={placeholderText}
         queryString={queryString}
+        sortByString={sortByString}
         onSelect={onSelect}
       />
     </PageContentModal>
@@ -41,6 +43,7 @@ SelectModal.propTypes = {
   isOpen: React.PropTypes.bool.isRequired,
   options: React.PropTypes.object.isRequired,
   queryString: React.PropTypes.string.isRequired,
+  sortByString: React.PropTypes.string.isRequired,
   placeholderText: React.PropTypes.string,
   onClose: React.PropTypes.func,
   onSelect: React.PropTypes.func.isRequired,


### PR DESCRIPTION
fixes #116 

Could reduce:

```
SelectModal.propTypes = {
  isOpen: React.PropTypes.bool.isRequired,
  options: React.PropTypes.object.isRequired,
  queryString: React.PropTypes.string.isRequired,
  sortByString: React.PropTypes.string.isRequired,
  placeholderText: React.PropTypes.string,
  onClose: React.PropTypes.func,
  onSelect: React.PropTypes.func.isRequired,
```

to:

```
SelectModal.propTypes = {
  ...AutocompleteSelector.propTypes,
  isOpen: React.PropTypes.bool.isRequired,
  onClose: React.PropTypes.func,
};
```

Though I think it can be good not having to run down a rabbit hole to find out what the prototypes for wrapped components are.
