### PR TITLE
Revert "User can tap on results to dismiss keyboard"

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react": "^15.2.1",
     "react-dom": "^15.2.1",
     "react-native": "^0.30.0",
-    "react-native-autocomplete-input": "edmofro/react-native-autocomplete-input",
+    "react-native-autocomplete-input": "^1.1.0",
     "react-native-modalbox": "edmofro/react-native-modalbox",
     "react-native-uuid": "^1.4.8",
     "react-native-vector-icons": "^2.0.2",

--- a/src/widgets/AutocompleteSelector.js
+++ b/src/widgets/AutocompleteSelector.js
@@ -49,8 +49,6 @@ export class AutocompleteSelector extends React.Component {
         autoCapitalize="none"
         autoCorrect={false}
         data={options.filtered(queryString, this.state.queryText).sorted(sortByString)}
-        keyboardShouldPersistTaps={false}
-        resultsShouldPersistAfterEditing
         onChangeText={text => this.setState({ queryText: text })}
         placeholder={placeholderText}
         renderItem={(item) => (


### PR DESCRIPTION
Reverts sussol/mobile#213
Although it allowed dismissing keyboard by tapping in the results, it meant the first tap didn't select the result, which doesn't feel so good. Can always push android physical back button to dismiss the keyboard.
