### PR TITLE
Prevent crashes when deleting rows of data

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
   },
   "dependencies": {
     "base-64": "^0.1.0",
-    "react": "15.3.1-rc.2",
-    "react-dom": "15.3.1-rc.2",
+    "react": "~15.3.1",
+    "react-dom": "~15.3.1",
     "react-native": "edmofro/react-native#natively-loopable-animations-0.34-stable",
     "react-native-autocomplete-input": "^1.1.0",
     "react-native-localization": "^0.1.17",
@@ -71,7 +71,7 @@
     "flow-bin": "^0.28.0",
     "jest-cli": "^13.2.3",
     "promise-sync-es6": "0.0.4",
-    "react-addons-test-utils": "15.3.1-rc.2",
+    "react-addons-test-utils": "~15.3.1",
     "react-native-mock": "0.2.4",
     "sinon": "^1.17.3"
   }

--- a/src/database/schema.js
+++ b/src/database/schema.js
@@ -141,5 +141,5 @@ export const schema =
       StocktakeBatch,
       User,
     ],
-    schemaVersion: 1,
+    schemaVersion: 2,
   };

--- a/src/pages/GenericTablePage.js
+++ b/src/pages/GenericTablePage.js
@@ -292,6 +292,7 @@ export class GenericTablePage extends React.Component {
   }
 
   renderRow(rowData, sectionId, rowId) {
+    if (!rowData.isValid()) return null; // Don't render if the row's data has been deleted
     const cells = [];
     const isExpanded = this.state.expandedRows.includes(rowData.id);
     // Make rows alternate background colour


### PR DESCRIPTION
- Fixes #348
- I believe an update to react native that removed some of the
  shouldComponentUpdate rules means that the datatable is now updating
  directly after setState({ selection: [] }), and before the refreshData
  is called, resulting in it trying to render a deleted record
- Could call refreshData prior to the setState, but would need to call
  it again immediately after, so seems a bit excessive
- This way also prevents future bugs
