### PR TITLE
Tables scroll to top when pruned

### DIFF
--- a/src/pages/GenericTablePage.js
+++ b/src/pages/GenericTablePage.js
@@ -124,7 +124,10 @@ export class GenericTablePage extends React.Component {
     if (causedBy === 'sync' &&
         this.dataTypesSynchronised.indexOf(recordType) >= 0) this.refreshData();
     // Ensure finalising updates data for the primary data type
-    else if (recordType === this.finalisableDataType && record.isFinalised) this.refreshData();
+    else if (recordType === this.finalisableDataType && record.isFinalised) {
+      this.refreshData();
+      if (this.dataTableRef) this.dataTableRef.scrollTo({ y: 0 });
+    }
   }
 
   onSearchChange(event) {


### PR DESCRIPTION
fixes #322 

Tested only in emulator, seems stable.

If the user filled out rows more than what fits in the table (~12) and finalises/prunes, the table will scroll up to bring the last of the remaining items into view.
