### PR TITLE
Check incoming sync records have fields that can and can't be blank

### DIFF
--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -563,6 +563,7 @@ export function sanityCheckIncomingRecord(recordType, record) {
       record[fieldName] !== null &&  // Key must exist
       record[fieldName].length > 0,  // And must not be blank
       true);
+  if (!hasAllNonBlankFields) return false; // Return early if record already not valid
   const hasRequiredFields = requiredFields[recordType].canBeBlank.reduce(
     (containsAllFieldsSoFar, fieldName) =>
       containsAllFieldsSoFar &&


### PR DESCRIPTION
* PR #391 Removed requirement for fields to have contents, as I
realised some item lines with no batch were being missed entirely.
However, removing the requirement entirely is overcooking it, we still
need to ensure all, e.g., item_ID fields contain some actual ID. This
PR fixes that, by checking for both fields that must contain something,
and those that needn’t.