### PR TITLE
Specify screen support for google play

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,12 @@
     package="com.msupplymobile">
 
     <uses-permission android:name="android.permission.INTERNET" />
-
+    <supports-screens 
+        android:smallScreens="false"
+        android:normalScreens="false"
+        android:largeScreens="false"
+        android:requiresSmallestWidthDp="720"
+    />
     <application
       android:name=".MainApplication"
       android:allowBackup="true"


### PR DESCRIPTION
Small, Normal *and* Large are basically phone screens or small low res tablets, which mSupply Mobile is not practically usable on.

Use table 3 here for reference: https://developer.android.com/guide/practices/screens_support.html#testing