### PR TITLE
#5271 fix annoying alert to confirm duplicate patient

### DIFF
--- a/src/widgets/modalChildren/PatientEditModal.js
+++ b/src/widgets/modalChildren/PatientEditModal.js
@@ -55,33 +55,34 @@ const PatientEditModalComponent = ({
 }) => {
   const isFocused = useIsFocused();
   const [alertText, setAlertText] = useState(modalStrings.are_you_sure_duplicate_patient);
+  const [removeModalOpen, toggleRemoveModal] = useToggle();
+  const [cannotDeleteModalOpen, toggleCannotDeleteModal] = useToggle();
+  const [canDuplicatePatient, setDuplicatePatient] = useState(false);
 
   let canSave = canSaveForm && canEditPatient;
-  let canDuplicatePatient = false;
-
   const hasVaccineEvents = hasVaccineEventsForm;
+  const canDelete = canEditPatient;
+  const showDelete = !isCreatePatient;
 
   if (canSave && !!surveySchema) {
     canSave = surveySchema && surveyForm && nameNoteIsValid;
   }
 
-  canDuplicatePatient = canSave && isDuplicatePatientLocally && isCreatePatient;
   useEffect(() => {
-    const dateOfBirth = moment(completedForm.dateOfBirth).format('LL');
-    const name = `${completedForm.firstName} ${completedForm.lastName}`;
-    const alert = modalStrings.formatString(
-      modalStrings.are_you_sure_duplicate_patient,
-      name,
-      dateOfBirth
-    );
-    setAlertText(alert);
+    if (isDuplicatePatientLocally && isCreatePatient) {
+      setDuplicatePatient(true);
+      const dateOfBirth = moment(completedForm.dateOfBirth).format('LL');
+      const name = `${completedForm.firstName} ${completedForm.lastName}`;
+      const alert = modalStrings.formatString(
+        modalStrings.are_you_sure_duplicate_patient,
+        name,
+        dateOfBirth
+      );
+      setAlertText(alert);
+    }
   }, [isDuplicatePatientLocally]);
 
-  const canDelete = canEditPatient;
-  const showDelete = !isCreatePatient;
-
-  const [removeModalOpen, toggleRemoveModal] = useToggle();
-  const [cannotDeleteModalOpen, toggleCannotDeleteModal] = useToggle();
+  const onConfirmDuplicatePatient = () => setDuplicatePatient(false);
 
   return (
     <ModalContainer
@@ -160,9 +161,9 @@ const PatientEditModalComponent = ({
         <PaperModalContainer isVisible={canDuplicatePatient} onClose={cancelPatientEdit}>
           <PaperConfirmModal
             questionText={alertText}
-            confirmText={generalStrings.save}
+            confirmText={generalStrings.ok}
             cancelText={buttonStrings.cancel}
-            onConfirm={onSaveForm}
+            onConfirm={onConfirmDuplicatePatient}
             onCancel={cancelPatientEdit}
           />
         </PaperModalContainer>


### PR DESCRIPTION
Fixes #5271 

## Change summary

Explain and justify your changes

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Dispensary > Try to create a duplicate patient having same firstName, lastName, and DoB
- [ ] There should be alert with confirmation to create duplicate patient.
- [ ] If click Cancel then cancel the process and return back to patient list window
- [ ] If click OK then remains in the same window and fill the required fields then create patient.

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
