### PR TITLE
Show password button

### DIFF
--- a/src/widgets/FormInputs/FormPasswordInput.js
+++ b/src/widgets/FormInputs/FormPasswordInput.js
@@ -11,6 +11,8 @@ import { TextInput } from 'react-native';
 
 import globalStyles, { SUSSOL_ORANGE } from '../../globalStyles';
 import { authStrings } from '../../localization';
+import { IconButton } from '../IconButton';
+import { EyeIcon, EyeSlashIcon } from '../icons';
 
 export const FormPasswordInput = forwardRef(
   (
@@ -26,23 +28,33 @@ export const FormPasswordInput = forwardRef(
       value,
     },
     ref
-  ) => (
-    <TextInput
-      ref={ref}
-      autoCompleteType="password"
-      editable={isEditable}
-      onChangeText={onChangeText}
-      onSubmitEditing={onSubmitEditing}
-      placeholder={placeholder}
-      placeholderTextColor={placeholderTextColor}
-      returnKeyType={returnKeyType}
-      style={style}
-      underlineColorAndroid={underlineColorAndroid}
-      value={value}
-      secureTextEntry
-      selectTextOnFocus
-    />
-  )
+  ) => {
+    const [isHidden, setIsHidden] = React.useState(true);
+    return (
+      <>
+        <TextInput
+          ref={ref}
+          autoCompleteType="password"
+          editable={isEditable}
+          onChangeText={onChangeText}
+          onSubmitEditing={onSubmitEditing}
+          placeholder={placeholder}
+          placeholderTextColor={placeholderTextColor}
+          returnKeyType={returnKeyType}
+          style={style}
+          underlineColorAndroid={underlineColorAndroid}
+          value={value}
+          secureTextEntry={isHidden}
+          selectTextOnFocus
+        />
+        <IconButton
+          containerStyle={{ marginRight: 60 }}
+          onPress={() => setIsHidden(!isHidden)}
+          Icon={isHidden ? <EyeIcon /> : <EyeSlashIcon />}
+        />
+      </>
+    );
+  }
 );
 
 FormPasswordInput.defaultProps = {

--- a/src/widgets/icons.js
+++ b/src/widgets/icons.js
@@ -420,3 +420,23 @@ ClockIcon.propTypes = {
   style: PropTypes.object,
   color: PropTypes.string,
 };
+
+export const EyeIcon = ({ size, style, color }) => (
+  <FAIcon size={size} style={style} color={color} name="eye" />
+);
+EyeIcon.defaultProps = { size: 30, style: {}, color: SUSSOL_ORANGE };
+EyeIcon.propTypes = {
+  size: PropTypes.number,
+  style: PropTypes.object,
+  color: PropTypes.string,
+};
+
+export const EyeSlashIcon = ({ size, style, color }) => (
+  <FAIcon size={size} style={style} color={color} name="eye-slash" />
+);
+EyeSlashIcon.defaultProps = { size: 30, style: {}, color: SUSSOL_ORANGE };
+EyeSlashIcon.propTypes = {
+  size: PropTypes.number,
+  style: PropTypes.object,
+  color: PropTypes.string,
+};


### PR DESCRIPTION
Fixes #5394

## Change summary

Adds a button to toggle the password visibility. This applies to both the login and initialisation screens:

https://github.com/msupply-foundation/mobile/assets/9192912/e866acf4-4ba5-4263-b6f4-ba3adf62681a

![init](https://github.com/msupply-foundation/mobile/assets/9192912/0567d9fc-56f1-44a3-8b17-746d31c5be10)


## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Check that init and login still work
- [ ] And that you can show / hide the password

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
