### PR TITLE
#5406 don't create blank supplier requisitions

### DIFF
--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -796,7 +796,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
       const otherParty = database.getOrCreate('Name', record.name_ID);
       const enteredBy = database.getOrCreate('User', record.user_ID);
       const linkedRequisition = record.requisition_ID
-        ? database.getOrCreate('Requisition', record.requisition_ID)
+        ? database.get('Requisition', record.requisition_ID)
         : null;
       const linkedTransaction = record.linked_transaction_id
         ? database.getOrCreate('Transaction', record.linked_transaction_id)


### PR DESCRIPTION
#5406 don't create blank supplier requisitions

Fixes #5406 

## Change summary

For an existing transaction if there is linkedRequisition, just get it if exist don't try to create new requisition.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Get Fiji MOH data
- [ ] Setup mobile with site nuffield_pharm
- [ ] After login, there should not be any blank supplier requisitions created

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
