### PR TITLE
#5428 App crashing in dispensing mode

### DIFF
--- a/src/reducers/DispensaryReducer.js
+++ b/src/reducers/DispensaryReducer.js
@@ -58,14 +58,22 @@ export const DispensaryReducer = (state = initialState(), action) => {
       const { usingAdverseDrugReactions } = payload;
       const { dataSet } = state;
 
+      // Default to patient
+      let sortBy = 'createdDate';
+      let isAscending = false;
+
       const patientDataSet = usingAdverseDrugReactions
         ? 'patientWithAdverseDrugReactions'
         : 'patient';
 
       const prescriberDataSet = 'prescriber';
       const newDataSet = dataSet === patientDataSet ? prescriberDataSet : patientDataSet;
-
       const newColumns = getColumns(newDataSet);
+
+      if (newDataSet === 'prescriber') {
+        sortBy = 'firstName';
+        isAscending = true;
+      }
 
       const newData = UIDatabase.objects(newDataSet === patientDataSet ? 'Patient' : 'Prescriber');
 
@@ -73,8 +81,8 @@ export const DispensaryReducer = (state = initialState(), action) => {
         ...state,
         dataSet: newDataSet,
         columns: newColumns,
-        sortKey: 'createdDate',
-        isAscending: false,
+        sortKey: sortBy,
+        isAscending,
         searchTerm: '',
         data: newData,
       };


### PR DESCRIPTION
#5428 App crashing in dispensing mode

Fixes #5428 

## Change summary

Handle the sorting for both patient and prescriber independently.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Go to Dispensing page
- [ ] Default is Patient list view > Click to Prescriber it should not crash
- [ ] The sorting and list view should work properly when switching between the Patient and Prescriber.

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
