### PR TITLE
5539 fix lines disappearing in customer requisition

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "name": "mSupplyMobile",
   "//": "version must be in the format ${majorNumber}.${minorNumber}.${patchNumber}-rc${releaseCandidateNumber}",
-  "version": "8.7.0",
+  "version": "8.7.1",
   "private": false,
   "license": "MIT",
   "description": "Mobile app for use with the mSupply medical inventory control software",

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -720,11 +720,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
       break;
     }
     case 'RequisitionItem': {
-      const requisition = database.get('Requisition', record.requisition_ID);
-      // Technically, if the requisition is null, this item becomes an orphan record
-      // and shouldn't be saved.
-      // But for the history of the requisition and to investigate the orphaned item,
-      // we will save it.
+      const requisition = database.getOrCreate('Requisition', record.requisition_ID);
       internalRecord = {
         id: record.ID,
         requisition,


### PR DESCRIPTION
Fixes #5539 

## Change summary
Creates blank requisition in case requisition lines get synced before its requisition to the mobile.

## Test apk
[v8.7.1-rc1](https://store3.gofile.io/download/web/618cc9eb-3222-4cbf-94a9-fd684319aff4/mSupplyMobile-8_7_1-rc1-universal-release.apk)

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Create an internal (supplier) requisition (either from mSupply desktop/mobile store)
- [ ] Finalise it and sync and follow test 1
- [ ] Login to mobile app and in the Customer Requisitions > tap a newly created response requisition and lines will be there with all same details as of its corresponding internal order.

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
