### PR TITLE
5542 fix app crash when opening customer requisition

### DIFF
--- a/src/pages/CustomerRequisitionPage.js
+++ b/src/pages/CustomerRequisitionPage.js
@@ -281,7 +281,7 @@ export const CustomerRequisition = ({
     </View>
   );
 
-  const TopRightToggleItems = (
+  const TopRightToggleItems = () => (
     <>
       <ItemIndicatorToggle />
       <View style={localStyles.horizontalContainerToggles}>
@@ -427,6 +427,14 @@ const mapStateToProps = state => {
       data: selectIndicatorTableRows(customerRequisition),
       indicatorColumns: selectIndicatorTableColumns(customerRequisition),
     };
+  }
+
+  const { indicatorColumns } = customerRequisition;
+
+  if (!Array.isArray(indicatorColumns || [])) {
+    // Realm's result collection are often treated as plain objects by React's PropTypes checks
+    // even if they behave like arrays. So we convert them to arrays here.
+    return { ...customerRequisition, indicatorColumns: Array.from(indicatorColumns) };
   }
 
   return customerRequisition;


### PR DESCRIPTION
Fixes #5542 

## Change summary
- Fixes `TopRightToggleItems` component declaration.
- Fixes prop type checks for `indicatorColumns.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Follow steps in #5542 
- [ ] After upgrade, should open/run customer requisition without any errors or crahses

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
