### PR TITLE
5544 fix app crashing when creating stocktake

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "name": "mSupplyMobile",
   "//": "version must be in the format ${majorNumber}.${minorNumber}.${patchNumber}-rc${releaseCandidateNumber}",
-  "version": "8.7.1",
+  "version": "8.7.2",
   "private": false,
   "license": "MIT",
   "description": "Mobile app for use with the mSupply medical inventory control software",

--- a/src/database/DataTypes/Item.js
+++ b/src/database/DataTypes/Item.js
@@ -221,7 +221,7 @@ export class Item extends Realm.Object {
    * @param {Date} date
    * @return  {number}
    */
-  geTotalQuantityOnDate(date) {
+  getTotalQuantityOnDate(date) {
     if (date >= new Date()) return this.totalQuantity;
 
     const allMovements = UIDatabase.objects('TransactionBatch')

--- a/src/database/DataTypes/Requisition.js
+++ b/src/database/DataTypes/Requisition.js
@@ -306,14 +306,16 @@ export class Requisition extends Realm.Object {
       throw new Error('Cannot add items to a finalised requisition');
     }
 
-    this.program.items.forEach(({ item }) => {
-      // Cannot determine the usage of a response requisition until consumption is manually entered.
-      const usage = this.isRequest ? programDailyUsage(item, this.period) : 0;
+    this.program.items
+      .filter(({ item }) => !!item)
+      .forEach(({ item }) => {
+        // Cannot determine the usage of a response requisition until consumption is manually entered.
+        const usage = this.isRequest ? programDailyUsage(item, this.period) : 0;
 
-      // Defer calculating stock on hand for response requisitions to the `createRecord` call.
-      const stockOnHand = this.isRequest ? item.geTotalQuantityOnDate(this.period.endDate) : 0;
-      createRecord(database, 'RequisitionItem', this, item, usage, stockOnHand);
-    });
+        // Defer calculating stock on hand for response requisitions to the `createRecord` call.
+        const stockOnHand = this.isRequest ? item.getTotalQuantityOnDate(this.period.endDate) : 0;
+        createRecord(database, 'RequisitionItem', this, item, usage, stockOnHand);
+      });
   }
 
   /**

--- a/src/database/DataTypes/Requisition.js
+++ b/src/database/DataTypes/Requisition.js
@@ -306,16 +306,15 @@ export class Requisition extends Realm.Object {
       throw new Error('Cannot add items to a finalised requisition');
     }
 
-    this.program.items
-      .filter(({ item }) => !!item)
-      .forEach(({ item }) => {
-        // Cannot determine the usage of a response requisition until consumption is manually entered.
-        const usage = this.isRequest ? programDailyUsage(item, this.period) : 0;
+    this.program.items.forEach(({ item }) => {
+      if (!item) return;
+      // Cannot determine the usage of a response requisition until consumption is manually entered.
+      const usage = this.isRequest ? programDailyUsage(item, this.period) : 0;
 
-        // Defer calculating stock on hand for response requisitions to the `createRecord` call.
-        const stockOnHand = this.isRequest ? item.getTotalQuantityOnDate(this.period.endDate) : 0;
-        createRecord(database, 'RequisitionItem', this, item, usage, stockOnHand);
-      });
+      // Defer calculating stock on hand for response requisitions to the `createRecord` call.
+      const stockOnHand = this.isRequest ? item.getTotalQuantityOnDate(this.period.endDate) : 0;
+      createRecord(database, 'RequisitionItem', this, item, usage, stockOnHand);
+    });
   }
 
   /**

--- a/src/database/DataTypes/Stocktake.js
+++ b/src/database/DataTypes/Stocktake.js
@@ -370,12 +370,15 @@ export class Stocktake extends Realm.Object {
    */
   addItemsFromProgram(database) {
     if (!this.program) return false;
-    this.setItemsByID(
-      database,
-      this.program.items
-        .filter(masterListItem => masterListItem.item && masterListItem.item.id !== '')
-        .map(masterListItem => masterListItem.item.id)
-    );
+
+    const itemIds = this.program.items.reduce((acc, masterListItem) => {
+      if (masterListItem.item && masterListItem.item.id) {
+        acc.push(masterListItem.item.id);
+      }
+      return acc;
+    }, []);
+
+    this.setItemsByID(database, itemIds);
     return true;
   }
 }

--- a/src/database/DataTypes/Stocktake.js
+++ b/src/database/DataTypes/Stocktake.js
@@ -372,7 +372,9 @@ export class Stocktake extends Realm.Object {
     if (!this.program) return false;
     this.setItemsByID(
       database,
-      this.program.items.map(masterListItem => masterListItem.item.id)
+      this.program.items
+        .filter(masterListItem => masterListItem.item && masterListItem.item.id !== '')
+        .map(masterListItem => masterListItem.item.id)
     );
     return true;
   }

--- a/src/database/DataTypes/StocktakeBatch.js
+++ b/src/database/DataTypes/StocktakeBatch.js
@@ -25,7 +25,7 @@ export class StocktakeBatch extends Realm.Object {
    * @param  {Realm}  database
    */
   destructor(database) {
-    if (this.snapshotNumberOfPacks === 0 && this.itemBatch.numberOfPacks === 0) {
+    if (this.snapshotNumberOfPacks === 0 && this.itemBatch && this.itemBatch.numberOfPacks === 0) {
       database.delete('ItemBatch', this.itemBatch);
     }
   }

--- a/src/database/DataTypes/StocktakeBatch.js
+++ b/src/database/DataTypes/StocktakeBatch.js
@@ -75,6 +75,7 @@ export class StocktakeBatch extends Realm.Object {
    * @return  {boolean}
    */
   get isReducedBelowMinimum() {
+    if (!this.itemBatch) return false;
     const { totalQuantity: stockOnHand } = this.itemBatch;
 
     // Return true if |stockOnHand + stocktakebatch.difference| is negative.
@@ -92,6 +93,7 @@ export class StocktakeBatch extends Realm.Object {
    * @return  {boolean}
    */
   get isSnapshotOutdated() {
+    if (!this.itemBatch) return false;
     return this.snapshotTotalQuantity !== this.itemBatch.totalQuantity;
   }
 

--- a/src/database/DataTypes/StocktakeItem.js
+++ b/src/database/DataTypes/StocktakeItem.js
@@ -126,6 +126,7 @@ export class StocktakeItem extends Realm.Object {
     if (this.batches.some(batch => batch.isSnapshotOutdated)) {
       return true;
     }
+    if (!this.item) return false;
 
     // Check all item batches (with stock) are included by finding matching id in a stocktake batch
     // for this stocktake item.

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -1217,16 +1217,20 @@ const createTemperatureBreach = (
 };
 
 /**
- * Create a Message record. This will be sent to the server and requests tables
+ * Create a Message record for mobile upgrade communications.
+ * This will be sent to the server and requests tables
  * when an app is upgraded from some version to another.
  *
  * @param {Realm}  database    App-wide database interface
- * @param {String} fromVersion Which version the app is being upgraded from.
- * @param {String} toVersion   Which version the app is being upgraded too.
+ * @param {Object} messageBody Body data for the message (e.g., {fromVersion, toVersion, ...})
+ * where `fromVersion` is version the app is being upgraded from
+ * `toVersion` is version the app is being upgraded too.
+ * Plus any other key/values to include in the message body.
  */
 
-const createUpgradeMessage = (database, fromVersion, toVersion) => {
+const createUpgradeMessage = (database, messageBody = {}) => {
   const syncSiteId = database.getSetting(SETTINGS_KEYS.SYNC_SITE_ID);
+  const { fromVersion = '', toVersion = '', ...rest } = messageBody;
 
   const messages = database
     .objects('Message')
@@ -1236,6 +1240,7 @@ const createUpgradeMessage = (database, fromVersion, toVersion) => {
   let message = messages.length > 0 ? messages[0] : null;
   const body = {
     ...(message ? message.body : {}),
+    ...rest,
     fromVersion: versionToInteger(fromVersion),
     toVersion: versionToInteger(toVersion),
     fromVersionString: String(fromVersion),

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -1250,11 +1250,7 @@ const createUpgradeMessage = (database, fromVersion, toVersion) => {
     createdDate: message ? message.createdDate : new Date(),
   };
 
-  if (message === null) {
-    message = database.create('Message', newMessage);
-  } else {
-    message = database.update('Message', newMessage);
-  }
+  message = database.update('Message', newMessage);
   message.body = body;
 
   database.save('Message', message);

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -1232,10 +1232,13 @@ const createUpgradeMessage = (database, messageBody = {}) => {
   const syncSiteId = database.getSetting(SETTINGS_KEYS.SYNC_SITE_ID);
   const { fromVersion = '', toVersion = '', ...rest } = messageBody;
 
+  // There should only ever be one upgrade message at a time, but if there are more,
+  // just update the most recent one.
   const messages = database
     .objects('Message')
     .filtered('type == "mobile_upgrade"')
-    .sorted('createdDate', true);
+    .sorted('createdDate', true)
+    .slice(0, 1);
 
   let message = messages.length > 0 ? messages[0] : null;
   const body = {

--- a/src/utilities/dailyUsage.js
+++ b/src/utilities/dailyUsage.js
@@ -73,6 +73,9 @@ export const dailyUsage = item => {
  * @param {Period} period
  */
 export const programDailyUsage = (item, period) => {
+  if (!item || !item.batches) return 0;
+  if (!period || !period.endDate) return 0;
+
   const { batches, id: itemId } = item;
   const { endDate: periodEndDate } = period;
 


### PR DESCRIPTION
Fixes #5544 

## Change summary
- Handles creating stocktake for broken master list items (i.e items with no linked to them)
- Handles other broken item batch undefined error while viewing existing broken stocktake (most probably for existing civ stocktake)
- Creates version upgrade message record to notify mSupply central server to re-sync all broken master list items' proper information from the server to the mobile app.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Take civ datafile
- [ ] Create stocktake for programs like `PNLS-ANTIRETROVIRAUX ET IO`
- [ ] Tap ok to continue
- [ ] Should create stocktake without any errors
- [ ] App should not be crashed while opening already existed problem stocktake records from the list

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
