### PR TITLE
5465 fix serial number reset to 0

### DIFF
--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -695,7 +695,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
       // Otherwise, keep the serial number it was given in mSupply
       const { REQUISITION_SERIAL_NUMBER } = NUMBER_SEQUENCE_KEYS;
       const serialNumber =
-        record.linked_requisition_id !== '' && record.serial_number < 1
+        record.linked_requisition_id && record.serial_number < 1
           ? getNextNumber(database, REQUISITION_SERIAL_NUMBER)
           : record.serial_number;
 


### PR DESCRIPTION
Fixes #5465 

## Change summary

Fixes serial number reset to 0 issue both for supplier invoice as well customer requisition.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Create stock transfer from desktop store to mobile store, finalize it
- [ ] Sync and open a supplier invoice in mobile
- [ ] Should have valid serial number
- [ ] Create internal order from desktop store to mobile store, finalize it
- [ ] Sync and open a customer requisition in mobile
- [ ] Should have valid serial number

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
